### PR TITLE
Fix install command & text formatting

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ http://127.0.0.1:4000/ with your browser.
 Jekyll and its dependencies can also be installed using gem and bundler:
 
     gem install bundler
-    cd lime-web && bundler install
+    cd lime-web && bundle install
     jekyll build
 
 In Ubuntu/Debian you would need to install ruby header files

--- a/development.txt
+++ b/development.txt
@@ -28,7 +28,7 @@ projects web site will be reflected in our https://github.com/libremesh/lime-web
 In order to generate these pages locally:
 ----
 git clone https://github.com/libremesh/lime-web.git
-cd lime-web && bundler install
+cd lime-web && bundle install
 bundle exec jekyll serve
 ----
 For more details, check the https://github.com/libremesh/lime-web/blob/master/README[README] on Github.

--- a/docs/en_connecting_nodes.txt
+++ b/docs/en_connecting_nodes.txt
@@ -1,7 +1,7 @@
 ---
 ---
 Connecting to LibreMesh nodes
-========================
+=============================
 
 == Connecting to your own node
 


### PR DESCRIPTION
1. `bundler install` was not working, changed the guide to use `bundle install` instead, wich works.
2. fixed title underline so the template is rendered ok.