### PR TITLE
Supported hardware list: Updated Xiaomi and added YouHua

### DIFF
--- a/docs/hardware/index.txt
+++ b/docs/hardware/index.txt
@@ -21,6 +21,7 @@ you find the opportunity send us your contribution via git pull-request or mail.
 |Device|Flash|RAM|WAN port|2.4 GHz|5 GHz|LEDE target|LEDE profile|factory image |sysupgrade image
 |https://openwrt.org/toh/xiaomi/mir3[Xiaomi MiWiFi R3]|128 MB|128 MB|Yes|Yes|Yes|MT7620NAND||see link below|see link below
 |https://openwrt.org/toh/xiaomi/mir3g[Xiaomi Mi WiFi R3G] |128 MB|256 MB|Yes|Yes|Yes|ramips|mir3g||
+|https://openwrt.org/toh/hwdata/youhua/youhua_wr1200js[YouHua WR1200JS] |16 MB|128 MB|Yes|Yes|Yes|ramips|youhua_wr1200js||
 |https://openwrt.org/toh/tp-link/tl-wr842nd[TP-Link WR842ND] |||||||||
 |https://openwrt.org/toh/tp-link/tl-wr1043nd[TP-Link WR1043ND-v1] |||||||||
 |https://openwrt.org/toh/tp-link/tl-wdr3500[TP-Link WDR3500] |||||||||

--- a/docs/hardware/index.txt
+++ b/docs/hardware/index.txt
@@ -20,7 +20,7 @@ you find the opportunity send us your contribution via git pull-request or mail.
 |=======
 |Device|Flash|RAM|WAN port|2.4 GHz|5 GHz|LEDE target|LEDE profile|factory image |sysupgrade image
 |https://openwrt.org/toh/xiaomi/mir3[Xiaomi MiWiFi R3]|128 MB|128 MB|Yes|Yes|Yes|MT7620NAND||see link below|see link below
-|https://openwrt.org/toh/xiaomi/mini[Xiaomi Mi WiFi Mini] |||||||||
+|https://openwrt.org/toh/xiaomi/mir3g[Xiaomi Mi WiFi R3G] |128 MB|256 MB|Yes|Yes|Yes|ramips|mir3g||
 |https://openwrt.org/toh/tp-link/tl-wr842nd[TP-Link WR842ND] |||||||||
 |https://openwrt.org/toh/tp-link/tl-wr1043nd[TP-Link WR1043ND-v1] |||||||||
 |https://openwrt.org/toh/tp-link/tl-wdr3500[TP-Link WDR3500] |||||||||


### PR DESCRIPTION
Maybe we should add a column for notes, so that we can easily point out which routers need soldering (Xiaomi does require soldering, YouHua does not).