### PR TITLE
Chef does not support LibreMesh

### DIFF
--- a/_includes/side_nav.html
+++ b/_includes/side_nav.html
@@ -2,7 +2,6 @@
 <div class="panel">
     <ul class="fa-ul">
         <li><i class="fa-li fa fa-download" aria-hidden="true"></i><a href="https://downloads.libremesh.org/dayboot_rely/">Latest Release Firmware</a></li>
-        <li><i class="fa-li fa fa-download" aria-hidden="true"></i><a href="https://chef.libremesh.org">Build Firmware Online</a></li>
         <li><i class="fa-li fa fa-download" aria-hidden="true"></i><a href="/development.html">Build Firmware Locally</a></li>
         <li><i class="fa-li fa fa-code-fork" aria-hidden="true"></i><a href="https://github.com/libremesh/">Source Code</a></li>
         <li><i class="fa-li fa fa-envelope" aria-hidden="true"></i><a href="https://lists.libremesh.org/mailman/listinfo/lime-users">User Mailing List</a></li>


### PR DESCRIPTION
Maybe due to libremap-agent (see https://github.com/libremesh/lime-packages/pull/471), Chef does not support LibreMesh anymore, removing Chef from the lateral panel.