### PR TITLE
lime-map-agent is for usage with old webui, replacing with ubus-lime-location

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -142,11 +142,11 @@ Select (press space until when an asterisk `*` appears, like `<*>`) LibreMesh pa
 - LiMe -> lime-app (LimeApp)
 - LiMe -> Offline Documentation -> lime-docs-minimal (LibreMesh English documentation)
 - LiMe -> first-boot-wizard (first-boot-wizard)
-- LiMe -> lime-map-agent (LiMe LibreMap agent)
 - LiMe -> Offline Documentation -> lime-docs (LibreMesh minimal documentation)
 - LiMe -> lime-hwd-ground-routing (Manage 802.1q VLANs for ground routing)
 - LiMe -> lime-debug (libremesh debug utils)
 - LuCI -> Libraries -> luci-lib-libremap-babeld (LibreMap babeld plugi)
+- Ubus -> Applications -> ubus-lime-location (Libremap ubus status module)
 - Ubus -> Applications -> ubus-lime-batman-adv (B.A.T.M.A.N.-Adv ubus status module)
 - Ubus -> Applications -> ubus-lime-fbw (Libremesh first boot wizard ubus module)
 - Network -> pirania (pirania)
@@ -154,7 +154,7 @@ Select (press space until when an asterisk `*` appears, like `<*>`) LibreMesh pa
 - LiMe -> shared-state-pirania (Pirania vaucher module for shared-stat)
 - LiMe -> shared-state-persist (Persists shared-state in usb device)
 
-The packages at the bottom of this list are the non strictly required ones (e.g. from `lime-map-agent` down to `shared-state-persist`), consider removing some of them _only_ if the created image is too large and does not fit in the router memory.
+The packages at the bottom of this list are the non strictly required ones (e.g. from `lime-docs` down to `shared-state-persist`), consider removing some of them _only_ if the created image is too large and does not fit in the router memory.
 
 Save and exit.
 


### PR DESCRIPTION
[lime-map-agent](https://github.com/libremesh/lime-packages/blob/faed673052653800d3c10be2f62b416bd54f67d4/packages/lime-map-agent/Makefile) just pulls some dependencies for having LibreMap working with the old, LuCI based web interface.
lime-app uses ubus-lime-location instead.