### PR TITLE
Suggest to select packages for having encrypted mesh and HTTPS at the web interface

### DIFF
--- a/development.txt
+++ b/development.txt
@@ -133,6 +133,12 @@ Some more packages are recommended but not mandatory for a working LibreMesh net
 - LiMe -> Offline Documentation -> lime-docs (LibreMesh English documentation)
 - LiMe -> lime-hwd-ground-routing (Manage 802.1q VLANs for ground routing)
 - LiMe -> lime-debug (libremesh debug utils)
+- Network -> wpad-mesh-wolfssl (for password protected 802.11s mesh)
+
+Additionally and optionally, httpS for the web interface can be enabled selecting (beware that the web interace will be shown as *not trusted*):
+
+- Libraries -> libustream-wolfssl
+- Utilities -> Encryption -> px5g-standalone
 
 [NOTE]
 =========================


### PR DESCRIPTION
Using wolfssl allows us to have much smaller firmware than using OpenSSL.
Additionally, both wpad-mesh-wolfssl and libustream-wolfssl share the same dependency from libwolfssl.
See the discussion on https://github.com/libremesh/lime-packages/issues/613
Before merging it would be good if someone could test with OpenWrt 18.06 (I tested loosely on 19.07).
And I did not test if shared-state is affected.